### PR TITLE
Update ShellExecutor.java

### DIFF
--- a/src/dorkbox/executor/ShellExecutor.java
+++ b/src/dorkbox/executor/ShellExecutor.java
@@ -48,7 +48,7 @@ class ShellExecutor {
     static final boolean isMacOsX;
 
     static {
-        String osName = System.getProperty("os.name");
+        String osName = System.getProperty("os.name").toLowerCase();
         isWindows = osName.startsWith("windows");
         isMacOsX = osName.startsWith("mac") || osName.startsWith("darwin");
     }


### PR DESCRIPTION
On windows 10 it is necessary to check os name in lowercase in order to match